### PR TITLE
Fixed crash when running a blank command

### DIFF
--- a/Console.cpp
+++ b/Console.cpp
@@ -37,11 +37,21 @@ namespace swift
 	{
 		if(activated)
 		{
-			// 8 = delete, 13 = enter/return
-			if(!(t == 8 || t == 13) && t < 128)
+			// 8 = backspace, 13 = enter/return, 127 = delete
+			if(!(t == 8 || t == 13 || t == 127))
 			{
 				commandStr += t;
 				command.setString(commandStr);
+				
+				// wrap around
+				if(command.getGlobalBounds().width + prompt.getGlobalBounds().width >= background.getGlobalBounds().width)
+				{
+					char temp = commandStr[commandStr.getSize() - 1];
+					commandStr.erase(commandStr.getSize() - 1);
+					commandStr += '\n';
+					commandStr += temp;
+					command.setString(commandStr);
+				}
 			}
 			else if(t == 8)
 			{
@@ -51,18 +61,24 @@ namespace swift
 			}
 			else if(t == 13)
 			{
+				if(commandStr == "")
+					return;
 				outputStr = handleCommand(commandStr);
 				output.setString(outputStr);
 				
 				commandStr.clear();
 				command.setString(commandStr);
 			}
+			else if(t == 127)
+			{
+				// for the time being, we don't want it to do anything
+			}
 		}
 	}
 			
-	void Console::addCommand(const std::string& c, std::function<const std::string(std::vector<std::string> args)> f)
+	void Console::addCommand(const std::string& c, std::function<std::string(std::vector<std::string> args)> f)
 	{
-		commandList.insert(std::make_pair(c, f));
+		commandList.emplace(c, f);
 	}
 
 	bool Console::isActivated() const
@@ -74,8 +90,14 @@ namespace swift
 	{
 		activated = a;
 	}
+	
+	Console& Console::operator <<(const std::string& str)
+	{
+		lines.emplace_front(str, font, 14);
+		return *this;
+	}
 
-	const std::string Console::handleCommand(const std::string& c)
+	std::string Console::handleCommand(const std::string& c)
 	{
 		std::istringstream ss(c);
 		std::vector<std::string> args;
@@ -89,7 +111,7 @@ namespace swift
 		}
 		
 		if(commandList.count(args[0]) != 0)
-			return commandList[args[0]](args);
+			return commandList[args[0]](std::move(args));
 		else
 			return "Unknown command";
 	}

--- a/Console.hpp
+++ b/Console.hpp
@@ -8,6 +8,7 @@
 #include <deque>
 
 #include <SFML/System/String.hpp>
+#include <SFML/Window/Event.hpp>
 #include <SFML/Graphics/Text.hpp>
 #include <SFML/Graphics/RenderTarget.hpp>
 #include <SFML/Graphics/RenderStates.hpp>
@@ -24,14 +25,16 @@ namespace swift
 
 			void update(char t);
 
-			void addCommand(const std::string& c, std::function<const std::string(std::vector<std::string> args)> f);
+			void addCommand(const std::string& c, std::function<std::string(std::vector<std::string> args)> f);
 
 			bool isActivated() const;
 			void activate(bool a);
+			
+			Console& operator <<(const std::string& str);
 
 		private:
 			// returns a string of output from the command
-			const std::string handleCommand(const std::string& c);
+			std::string handleCommand(const std::string& c);
 			void draw(sf::RenderTarget& target, sf::RenderStates states) const;
 
 			sf::RectangleShape background;
@@ -47,9 +50,9 @@ namespace swift
 			sf::String outputStr;
 			sf::Text output;
 
-			//std::deque<sf::Text> lines;
+			std::deque<sf::Text> lines;
 
-			std::map<std::string, std::function<const std::string(std::vector<std::string> args)>> commandList;
+			std::map<std::string, std::function<std::string(std::vector<std::string> args)>> commandList;
 
 			bool activated;
 	};


### PR DESCRIPTION
Fixed some const correctness issues,
used std::move() on the vector in handleCommand
